### PR TITLE
preserve root-user status during pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ RUN apt-get install -y pkg-config
 # clean up
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# switch back to user
-USER $NB_USER
-
 # install necessary packages
 RUN pip3 install --upgrade pip && pip3 install numpy pydot networkx progressbar2 pymdptoolbox pygraphviz
+
+# switch back to user
+USER $NB_USER
 
 # make the dir with notebooks the working dir
 WORKDIR /mnt/hw3-tester


### PR DESCRIPTION
Hi Miguel,
When running the Dockerfile I had user privilege issues. Retaining root-user status through the pip install process fixed my issues. This seemed to work for my classmate Nick L. as well (per Piazza discussion).

Let me know if you'd like me to clarify or update anything else on this pull request.

Thanks!
Mitch