### PR TITLE
A few minor README and installation updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Recommended virtual environment name
+hw3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NOTE: We are using Python 3. Make sure you are too:
 
-```python --version
+```
 (hw3) $ python --version
 Python 3.6.1 :: Continuum Analytics, Inc.
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ python hw3_tester.py -vvv -m sample.json -i -s
 
 ```bash
 pip3 install numpy pydot networkx progressbar2 pygraphviz pymdptoolbox
+# or
+pip3 install -r requirements.txt
 ```
 
 ### pyraphiz failing to install?

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+decorator==4.3.0
+networkx==2.1
+numpy==1.14.4
+progressbar2==3.38.0
+pydot==1.2.4
+pygraphviz==1.3.1
+pymdptoolbox==4.0b3
+pyparsing==2.2.0
+python-utils==2.3.0
+scipy==1.1.0
+six==1.11.0


### PR DESCRIPTION
* declaring the syntax of the first snippet in the README as `python` was causing spurious syntax highlighting
* added a `.gitignore` for some common python filetypes as well as the `hw3` virtualenv directory, per the recommendation in the readme
* dumped a `requirements.txt` file representing a snapshot of the latest dependencies, which could be easier to use than installing everything explicitly

@mimoralea 