### PR TITLE
Specify Python 3.6 for Conda environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can run the testing script 3 different ways:
 
 ```bash
 # create conda environment and activate it
-conda create -n hw3 python=3
+conda create -n hw3 python=3.6
 source activate hw3
 
 # install dependencies


### PR DESCRIPTION
I was able to get the `pygraphviz` library installed, but running the tester yielded the following error:

```bash
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/pygraphviz/agraph.py", line 665, in out_edges_iter
    raise StopIteration
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "hw3_tester.py", line 313, in <module>
    main(args)
  File "hw3_tester.py", line 240, in main
    png_path = visualize_mdp(mdp, filename)
  File "hw3_tester.py", line 208, in visualize_mdp
    write_dot(G, filename.replace('.json', '.dot'))
  File "/usr/lib/python3.7/site-packages/networkx/drawing/nx_agraph.py", line 194, in write_dot
    A.clear()
  File "/usr/lib/python3.7/site-packages/pygraphviz/agraph.py", line 951, in clear
    self.remove_edges_from(self.edges())
  File "/usr/lib/python3.7/site-packages/pygraphviz/agraph.py", line 573, in edges
    return list(self.edges_iter(nbunch=nbunch, keys=keys))
  File "/usr/lib/python3.7/site-packages/pygraphviz/agraph.py", line 734, in edges_iter
    for e in self.out_edges_iter(keys=keys):
RuntimeError: generator raised StopIteration
```
I suspect this is because of PEP 479 being enabled for all code in Python 3.7 which is the default Python3 environment for recent installs of Conda. I specified 3.6 and re-created the environment - works now. Might make sense to specify the python version here.
